### PR TITLE
More fixes

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapifeatures10/collections/AbstractFeatures.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/collections/AbstractFeatures.java
@@ -17,12 +17,7 @@ import static org.testng.Assert.assertNotNull;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import org.opengis.cite.ogcapifeatures10.CommonDataFixture;
 import org.opengis.cite.ogcapifeatures10.SuiteAttribute;
@@ -166,8 +161,11 @@ public class AbstractFeatures extends CommonDataFixture {
                     "Feature Collection Metadata document must include links for alternate encodings. Missing links for types "
                                                 + typesWithoutLink );
 
-        // Validate that each link includes a rel and type parameter.
-        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links );
+        // Validate that each "self"/"alternate" link includes a rel and type parameter.
+        Set<String> rels = new HashSet<>();
+        rels.add("self");
+        rels.add("alternate");
+        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links, rels );
         assertTrue( linksWithoutRelOrType.isEmpty(),
                     "Links for alternate encodings must include a rel and type parameter. Missing for links "
                                                      + linksWithoutRelOrType );

--- a/src/main/java/org/opengis/cite/ogcapifeatures10/collections/Feature.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/collections/Feature.java
@@ -10,11 +10,7 @@ import static org.opengis.cite.ogcapifeatures10.util.JsonUtils.findUnsupportedTy
 import static org.opengis.cite.ogcapifeatures10.util.JsonUtils.linkIncludesRelAndType;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.opengis.cite.ogcapifeatures10.CommonDataFixture;
 import org.opengis.cite.ogcapifeatures10.SuiteAttribute;
@@ -158,10 +154,14 @@ public class Feature extends CommonDataFixture {
         assertTrue( linkIncludesRelAndType( linkToCollection ),
                     "Link to feature collection must include a rel and type parameter" );
 
-        // Verify that all links include the rel and type link parameters.
-        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links );
+        // Verify that all "self"/"alternate"/"collection" links include the rel and type link parameters.
+        Set<String> rels = new HashSet<String>();
+        rels.add("self");
+        rels.add("alternate");
+        rels.add("collection");
+        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links, rels );
         assertTrue( linksWithoutRelOrType.isEmpty(),
-                    "Links for alternate encodings in Get Feature Operation Response must include a rel and type parameter. Missing for links "
+                    "Links with link relation types 'self', 'alternate' and 'collection' in Get Feature Operation Response must include a rel and type parameter. Missing for links "
                                                      + linksWithoutRelOrType );
     }
 

--- a/src/main/java/org/opengis/cite/ogcapifeatures10/collections/FeatureCollections.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/collections/FeatureCollections.java
@@ -13,10 +13,7 @@ import static org.opengis.cite.ogcapifeatures10.util.JsonUtils.linkIncludesRelAn
 import static org.testng.Assert.assertNotNull;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.opengis.cite.ogcapifeatures10.CommonDataFixture;
 import org.opengis.cite.ogcapifeatures10.SuiteAttribute;
@@ -135,8 +132,11 @@ public class FeatureCollections extends CommonDataFixture {
                     "Feature Collections Metadata document must include links for alternate encodings. Missing links for types "
                                                 + typesWithoutLink );
 
-        // Requirement 13 B: All links SHALL include the rel and type link parameters.
-        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( alternateLinks );
+        // Requirement 13 B: All "self"/"alternate" links SHALL include the rel and type link parameters.
+        Set<String> rels = new HashSet<>();
+        rels.add("self");
+        rels.add("alternate");
+        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( alternateLinks, rels );
         assertTrue( linksWithoutRelOrType.isEmpty(),
                     "Links for alternate encodings must include a rel and type parameter. Missing for links "
                                                      + linksWithoutRelOrType );

--- a/src/main/java/org/opengis/cite/ogcapifeatures10/util/JsonUtils.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/util/JsonUtils.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
@@ -214,11 +215,11 @@ public class JsonUtils {
      *            list of links to search in, never <code>null</code>
      * @return the links without 'rel' or 'type' property
      */
-    public static List<String> findLinksWithoutRelOrType( List<Map<String, Object>> links ) {
+    public static List<String> findLinksWithoutRelOrType( List<Map<String, Object>> links, Set<String> rels ) {
         List<String> linksWithoutRelOrType = new ArrayList<>();
-        for ( Map<String, Object> alternateLink : links ) {
-            if ( !linkIncludesRelAndType( alternateLink ) )
-                linksWithoutRelOrType.add( (String) alternateLink.get( "href" ) );
+        for ( Map<String, Object> link : links ) {
+            if ( rels.contains(link.get( "rel" )) && !linkIncludesRelAndType( link ) )
+                linksWithoutRelOrType.add( (String) link.get( "href" ) );
         }
         return linksWithoutRelOrType;
     }

--- a/src/test/java/org/opengis/cite/ogcapifeatures10/util/JsonUtilsTest.java
+++ b/src/test/java/org/opengis/cite/ogcapifeatures10/util/JsonUtilsTest.java
@@ -30,9 +30,7 @@ import java.net.URL;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -183,7 +181,10 @@ public class JsonUtilsTest {
     @Test
     public void testFindLinksWithoutRelOrType() {
         List<Map<String, Object>> links = jsonCollection.getList( "links" );
-        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links );
+        Set<String> rels = new HashSet<>();
+        rels.add("self");
+        rels.add("alternate");
+        List<String> linksWithoutRelOrType = findLinksWithoutRelOrType( links, rels );
 
         assertThat( linksWithoutRelOrType.size(), is( 0 ) );
     }


### PR DESCRIPTION
This PR fixes two issues in the current ETS:

* Some tests check that all links have rel/type properties. However, the requirement only applies to the links for the link relation types in scope of the requirements. Typically this is self/alternate. The tests have been limited to the link relation types according to the requirements.
* The media type tests are too simple to do not support the various variations that are allowed.