### PR TITLE
Manage paths lists with api urlBase

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapifeatures10/openapi3/OpenApiUtils.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/openapi3/OpenApiUtils.java
@@ -352,7 +352,11 @@ public class OpenApiUtils {
     		String pathString = pathItemObject.getPathString();
     		Map<String, Operation> operationObjects = pathItemObject.getOperations();
             for ( Operation operationObject : operationObjects.values() ) {
-            	if (operationObject.getOperationId() == "getRoot") {
+            	String operationId = operationObject.getOperationId();
+            	if (operationId != null && operationId.equals("getRoot")) {
+            		if (pathString.endsWith("/")) {
+            			pathString = pathString.substring(0, pathString.length() - 1);
+            		}
             		return pathString;
             	}
             }


### PR DESCRIPTION
Hello, 

I hope you can accept this PR. It solves the following situation. 

When having an OGC Api based on [pg_featureserv ](https://github.com/CrunchyData/pg_featureserv) project  you have the chance to define a urlBase . In our use case, this approach is needed because of our architecture.  We are producing the following schema.

![image](https://user-images.githubusercontent.com/5648254/138700017-1967e201-e654-44c3-86ac-ab337d4406d0.png)

The current code produces wrong testing URLs, and makes pattern  "/conformance" not be reachable. This produce an emtpy list and the code creates a list with one item with "dummydata".

The code is merging "https://gisco-development.northeurope.cloudapp.azure.com/features/" as url base with api paths like "/features/conformance". This makes a nonexisting paths like https://gisco-development.northeurope.cloudapp.azure.com/features/features/conformance.

With this PR we have a solution for [the issue](https://github.com/opengeospatial/ets-ogcapi-features10/issues/180).

