### PR TITLE
Support cases where CRS is not supported

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapifeatures10/conformance/crs/CrsRequirementClassPrecondition.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/conformance/crs/CrsRequirementClassPrecondition.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.opengis.cite.ogcapifeatures10.conformance.RequirementClass;
 import org.testng.ITestContext;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -31,6 +32,10 @@ public class CrsRequirementClassPrecondition {
     public void verifyRequirementClass() {
         boolean requirementClassIsImplemented = this.requirementClasses != null
                                                 && this.requirementClasses.contains( CRS );
+        if (!requirementClassIsImplemented) {
+            throw new SkipException("Requirement class " + CRS.name()
+                    + " is not supported by the test instance. Tests will be skipped." );
+        }
         assertTrue( requirementClassIsImplemented, "Requirement class " + CRS.name()
                                                    + " is not supported by the test instance. Tests will be skipped." );
     }


### PR DESCRIPTION
Hi

As mentioned here https://github.com/opengeospatial/ets-ogcapi-features10/issues/185 the tests fail if the service tested does not support CRS. As CRS support is not mandatory for a OGC API Feature service, then I think the CRS tests should be skipped. This way only if a service supports CRS the CRS tests will run.

Fixes #185.

Thanks.