### PR TITLE
Upgrade io.fabric8:docker-maven-plugin:0.28.0 -> 0.45.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.28.0</version>
+          <version>0.45.1</version>
           <configuration>
             <images>
               <image>


### PR DESCRIPTION
Upgrade the `docker-maven-plugin` to the latest version to make it work with Docker Desktop for MacOS.

Getting the error described here otherwise:

https://github.com/fabric8io/docker-maven-plugin/issues/1257