### PR TITLE
Fix global crs codes lookup in discovery collections crs tests

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrs.java
+++ b/src/main/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrs.java
@@ -38,7 +38,7 @@ public class DiscoveryCollectionsStorageCrs extends AbstractDiscoveryCollections
      */
     @Test(description = "Implements A.1 Discovery, Abstract Test 2 (Requirement /req/crs/fc-md-storageCrs-valid-value), "
                         + "storageCrs property in the collection objects in the path /collections", dataProvider = "collectionItemUris", dependsOnGroups = "crs-conformance")
-    public void verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs( TestPoint testPoint, JsonPath jsonPath,
+    public void verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs( TestPoint testPoint, JsonPath jsonPath,
                                                                               Map<String, Object> collection ) {
         String collectionId = (String) collection.get( "id" );
         String storageCrs = (String) collection.get( "storageCrs" );
@@ -47,15 +47,18 @@ public class DiscoveryCollectionsStorageCrs extends AbstractDiscoveryCollections
                                                     collectionId, testPoint.getPath() ) );
         }
         List<String> crs = JsonUtils.parseAsList( "crs", collection );
-        if ( crs.size() == 1 && "#/crs".equals( crs.get( 0 ) ) ) {
-            List<String> globalCrsList = JsonUtils.parseAsList( "crs", jsonPath );
-            if ( !globalCrsList.contains( storageCrs ) ) {
-                throw new AssertionError( String.format( "Collection with id '%s' at collections path %s specifies the storageCrs '%s' which is not declared in the global list of CRSs",
-                                                         collectionId, testPoint.getPath(), storageCrs ) );
-            }
-        } else if ( !crs.contains( storageCrs ) ) {
-            throw new AssertionError( String.format( "Collection with id '%s' at collections path %s specifies the storageCrs '%s' which is not declared as crs property",
+
+        if ( !crs.contains( storageCrs ) ) {
+            if( crs.contains("#/crs") ) {
+                List<String> globalCrsList = JsonUtils.parseAsList( "crs", jsonPath );
+                if ( !globalCrsList.contains( storageCrs ) ) {
+                    throw new AssertionError( String.format( "Collection with id '%s' at collections path %s specifies the storageCrs '%s' which is not declared in the global list of CRSs",
+                                                             collectionId, testPoint.getPath(), storageCrs ) );
+                }
+            } else {
+                throw new AssertionError( String.format( "Collection with id '%s' at collections path %s specifies the storageCrs '%s' which is not declared as crs property",
                                                      collectionId, testPoint.getPath(), storageCrs ) );
+            }
         }
     }
 

--- a/src/test/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrsTest.java
+++ b/src/test/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrsTest.java
@@ -1,0 +1,138 @@
+package org.opengis.cite.ogcapifeatures10.conformance.crs.discovery.collections;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.cite.ogcapifeatures10.openapi3.TestPoint;
+import org.testng.ISuite;
+import org.testng.ITestContext;
+
+import io.restassured.path.json.JsonPath;
+
+/**
+ * @author <a href="mailto:gabriel.roldan@camptocamp.com">Gabriel Roldan</a>
+ */
+public class DiscoveryCollectionsDefaultCrsTest {
+    private static ITestContext testContext;
+
+    private static TestPoint testPoint;
+
+    /**
+     * Sample response from a {@code /collections} endpoint. Contains ex
+     */
+    private static JsonPath collectionsResponse;
+
+    private DiscoveryCollectionsDefaultCrs discoveryCollectionsDefaultCrs;
+
+    @BeforeClass
+    public static void initTestFixture() throws Exception {
+        testContext = mock(ITestContext.class);
+        ISuite suite = mock(ISuite.class);
+        when(testContext.getSuite()).thenReturn(suite);
+
+        testPoint = new TestPoint("http://localhost:8080/api/ogc/features/v1", "/collections", Collections.emptyMap());
+
+        collectionsResponse = prepareCollections();
+    }
+
+    @Before
+    public void setUp() {
+        discoveryCollectionsDefaultCrs = new DiscoveryCollectionsDefaultCrs();
+        discoveryCollectionsDefaultCrs.initCommonFixture(testContext);
+    }
+
+    /**
+     * Test a collection whose crs contains both its {@code storageCrs} and the
+     * global {@code #/crs} pointer
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs_globalCrsAndStorageCrs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[0]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("sf:archsites", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/26713"));
+        assertThat(crs, containsInAnyOrder("#/crs", "http://www.opengis.net/def/crs/EPSG/0/26713"));
+
+        // test
+        discoveryCollectionsDefaultCrs.verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose crs contains only the global {@code #/crs} pointer
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs_globalCrs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[1]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("ne:populated_places", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/OGC/1.3/CRS84"));
+        assertThat(crs, contains("#/crs"));
+
+        // test
+        discoveryCollectionsDefaultCrs.verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose crs contains a list of crs identifiers without the
+     * global {@code #/crs} pointer
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[2]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("sf:bugsites", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/26713"));
+        assertThat(crs, contains("http://www.opengis.net/def/crs/EPSG/0/26713",
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"));
+
+        // test
+        discoveryCollectionsDefaultCrs.verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose crs does not declare any of the default CRS nor has
+     * the global {@code #/crs} pointer
+     */
+    @Test(expected = AssertionError.class)
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs_no_default_crs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[3]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("no_default_crs", collection.get("id"));
+
+        // AssertionError expected here
+        discoveryCollectionsDefaultCrs.verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    private static JsonPath prepareCollections() {
+        return new JsonPath(Objects
+                .requireNonNull(DiscoveryCollectionsDefaultCrsTest.class.getResourceAsStream("collections.json")));
+    }
+}

--- a/src/test/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrsTest.java
+++ b/src/test/java/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrsTest.java
@@ -1,0 +1,197 @@
+package org.opengis.cite.ogcapifeatures10.conformance.crs.discovery.collections;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengis.cite.ogcapifeatures10.openapi3.TestPoint;
+import org.testng.ISuite;
+import org.testng.ITestContext;
+
+import io.restassured.path.json.JsonPath;
+
+/**
+ * @author <a href="mailto:gabriel.roldan@camptocamp.com">Gabriel Roldan</a>
+ */
+public class DiscoveryCollectionsStorageCrsTest {
+    private static ITestContext testContext;
+
+    private static TestPoint testPoint;
+
+    /**
+     * Sample response from a {@code /collections} endpoint. Contains ex
+     */
+    private static JsonPath collectionsResponse;
+
+    private DiscoveryCollectionsStorageCrs discoveryCollectionsStorageCrs;
+
+    @BeforeClass
+    public static void initTestFixture() throws Exception {
+        testContext = mock(ITestContext.class);
+        ISuite suite = mock(ISuite.class);
+        when(testContext.getSuite()).thenReturn(suite);
+
+        testPoint = new TestPoint("http://localhost:8080/api/ogc/features/v1", "/collections", Collections.emptyMap());
+
+        collectionsResponse = prepareCollections();
+    }
+
+    @Before
+    public void setUp() {
+        discoveryCollectionsStorageCrs = new DiscoveryCollectionsStorageCrs();
+        discoveryCollectionsStorageCrs.initCommonFixture(testContext);
+    }
+
+    /**
+     * Test a collection whose crs contains both its {@code storageCrs} and the
+     * global {@code #/crs} pointer
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs_globalCrsAndStorageCrs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[0]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("sf:archsites", collection.get("id"));
+
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/26713"));
+        assertThat(crs, contains("http://www.opengis.net/def/crs/EPSG/0/26713", "#/crs"));
+
+        // test
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose crs contains only the global {@code #/crs} pointer,
+     * and the global crs property contains the collection's storageCrs
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs_globalCrs_only() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[1]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("ne:populated_places", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/OGC/1.3/CRS84"));
+        assertThat(crs, contains("#/crs"));
+
+        // test
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose crs contains its {@code storageCrs} and no global
+     * {@code #/crs} pointer
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[2]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("sf:bugsites", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/26713"));
+        assertThat(crs, containsInAnyOrder("http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "http://www.opengis.net/def/crs/EPSG/0/26713"));
+
+        // test
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose storageCrs is declared in the global crs but not on
+     * its crs property, but it does contain the global {@code #/crs} pointer.
+     */
+    @Test
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs_globalCrs_and_custom_crs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[4]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("storageCrsInGlobalCrs", collection.get("id"));
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/4087"));
+        assertThat(crs, containsInAnyOrder("#/crs", "http://www.opengis.net/def/crs/EPSG/0/3786"));
+
+        @SuppressWarnings("unchecked")
+        List<String> globalCrs = (List<String>) collectionsResponse.get("crs");
+        assertTrue(globalCrs.contains("http://www.opengis.net/def/crs/EPSG/0/4087"));
+
+        // AssertionError expected here
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    /**
+     * Test a collection whose storageCrs is not declared in its crs and has no
+     * pointer to the global crs
+     */
+    @Test(expected = AssertionError.class)
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs_no_storage_crs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[5]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("storageCrsUndeclared", collection.get("id"));
+
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/4088"));
+        assertThat(crs, not(contains("#/crs")));
+
+        @SuppressWarnings("unchecked")
+        List<String> globalCrs = (List<String>) collectionsResponse.get("crs");
+        assertFalse(globalCrs.contains("http://www.opengis.net/def/crs/EPSG/0/4088"));
+
+        // AssertionError expected here
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testVerifyCollectionsPathCollectionCrsPropertyContainsStorageCrs_no_storage_crs_in_global_crs() {
+        Map<String, Object> collection = collectionsResponse.getMap("collections[6]");
+        // preflight checks
+        assertNotNull(collection);
+        assertEquals("storageCrsUndeclaredInGlobalCrs", collection.get("id"));
+
+        @SuppressWarnings("unchecked")
+        List<String> crs = (List<String>) collection.get("crs");
+        assertThat(collection.get("storageCrs"), equalTo("http://www.opengis.net/def/crs/EPSG/0/4088"));
+        assertThat(crs, contains("#/crs"));
+
+        @SuppressWarnings("unchecked")
+        List<String> globalCrs = (List<String>) collectionsResponse.get("crs");
+        assertFalse(globalCrs.contains("http://www.opengis.net/def/crs/EPSG/0/4088"));
+
+        // AssertionError expected here
+        discoveryCollectionsStorageCrs.verifyCollectionsPathCollectionCrsPropertyContainsStorageCrs(testPoint,
+                collectionsResponse, collection);
+    }
+
+    private static JsonPath prepareCollections() {
+        return new JsonPath(Objects
+                .requireNonNull(DiscoveryCollectionsStorageCrsTest.class.getResourceAsStream("collections.json")));
+    }
+}

--- a/src/test/resources/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/collections.json
+++ b/src/test/resources/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/collections.json
@@ -60,7 +60,7 @@
         "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
       ],
       "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/26713"
-    },    
+    },
     {
       "id": "no_default_crs",
       "title": "Bogus crs sample",
@@ -77,11 +77,39 @@
         "http://www.opengis.net/def/crs/EPSG/0/26713"
       ],
       "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/26713"
+    },
+    {
+      "id": "storageCrsInGlobalCrs",
+      "title": "Storage Crs In Global Crs",
+      "description": "Sampe collection whose storageCrs is only declared in the global crs, but has more codes on its crs property",
+      "crs": [
+        "http://www.opengis.net/def/crs/EPSG/0/3786",
+        "#/crs"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/4087"
+    },
+    {
+      "id": "storageCrsUndeclared",
+      "title": "Storage Crs Undeclared In Global crs",
+      "description": "Sample whose storageCrs is not declared in its crs",
+      "crs": [
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/4088"
+    },
+    {
+      "id": "storageCrsUndeclaredInGlobalCrs",
+      "title": "Storage Crs Undeclared In Global crs",
+      "description": "Sample whose storageCrs is not declared in its crs nor in the global crs",
+      "crs": [
+        "#/crs"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/4088"
     }    
   ],
   "crs": [
     "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "http://www.opengis.net/def/crs/EPSG/0/4326",
-    "http://www.opengis.net/def/crs/EPSG/0/3857"
+    "http://www.opengis.net/def/crs/EPSG/0/3857",
+    "http://www.opengis.net/def/crs/EPSG/0/4087"
   ]
 }

--- a/src/test/resources/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/collections.json
+++ b/src/test/resources/org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/collections.json
@@ -1,0 +1,87 @@
+{
+  "links": [
+    {
+      "href": "http://localhost/api/ogc/features/v1/collections?f=json",
+      "rel": "self",
+      "type": "application/json",
+      "title": "This document"
+    }
+  ],
+  "collections": [
+    {
+      "id": "sf:archsites",
+      "title": "Spearfish archeological sites",
+      "description": "Sample collection with a crs property having both its storageCrs and the #/crs JSON pointer",
+      "extent": {
+        "spatial": {
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+          "bbox": [
+            [ -103.8725637911543, 44.37740330855979, -103.63794182141925, 44.48804280772808 ]
+          ]
+        }
+      },
+     "crs": [
+        "http://www.opengis.net/def/crs/EPSG/0/26713",
+        "#/crs"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/26713"
+    },
+    {
+      "id": "ne:populated_places",
+      "title": "Populated Places",
+      "description": "Sample collection whose crs property contains only the #/crs JSON pointer and the root crs list contains its storageCrs",
+      "extent": {
+        "spatial": {
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+          "bbox": [
+            [ -175.2205644999999, -41.29206799231509, 179.2166470999999, 64.14345946317033 ]
+          ]
+        }
+      },
+      "crs": [
+        "#/crs"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    },
+    {
+      "id": "sf:bugsites",
+      "title": "Spearfish bug locations",
+      "description": "Sample collection with no #/crs pointer",
+      "extent": {
+        "spatial": {
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+          "bbox": [
+            [ -103.86796132, 44.37393882, -103.63773523, 44.43418821 ]
+          ]
+        }
+      },
+      "crs": [
+        "http://www.opengis.net/def/crs/EPSG/0/26713",
+        "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/26713"
+    },    
+    {
+      "id": "no_default_crs",
+      "title": "Bogus crs sample",
+      "description": "Sample collection with no #/crs pointer and no default crs declared",
+      "extent": {
+        "spatial": {
+          "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+          "bbox": [
+            [ -103.86796132, 44.37393882, -103.63773523, 44.43418821 ]
+          ]
+        }
+      },
+      "crs": [
+        "http://www.opengis.net/def/crs/EPSG/0/26713"
+      ],
+      "storageCrs": "http://www.opengis.net/def/crs/EPSG/0/26713"
+    }    
+  ],
+  "crs": [
+    "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "http://www.opengis.net/def/crs/EPSG/0/4326",
+    "http://www.opengis.net/def/crs/EPSG/0/3857"
+  ]
+}


### PR DESCRIPTION
* Fix `DiscoveryCollectionsStorageCrs` look up of global crs
    `DiscoveryCollectionsStorageCrs` asserts that a `/collections` document complies with

    ```
    Abstract Test 3: /conf/crs/storageCrs
    Test Purpose: Verify that the storage CRS identifier is a valid value

    Test Method: For each collection object that includes a storageCrs property in the paths /collections and
    /collections/{collectionId}, validate that the string is also found in the crs property of the collection or, in case
    the crs property includes a value #/crs, in the global list of CRSs.
    ```

  but doesn't expand the collection's `#/crs` JSON pointer to the collections document crs list.
  This patch fixes it and adds unit tests to cover all possible cases.

* Fix `DiscoveryCollectionsDefaultCrs` look up of codes in the global crs

   `DiscoveryCollectionsDefaultCrs` asserts that a `/collections` document complies with

    ```
     Abstract Test 2: /conf/crs/default-crs
     Test Purpose: Verify that the list of supported CRSs includes the default CRS.
     Requirement: /req/crs/fc-md-crs-list B
    ```

    but doesn't expand the collection's `#/crs` JSON pointer to the collections document crs list.

    This patch fixes it and adds unit tests to cover all possible cases.

---
Fixes #251
